### PR TITLE
Fix package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from distutils.core import setup
 setup(
     name = 'py_trace_event',
-    packages = ['trace_event'],
+    packages = ['trace_event_impl'],
     version = '0.1.0',
     description = 'Performance tracing for python',
     author='Nat Duca'


### PR DESCRIPTION
Folder 'trace_event' was renamed to 'trace_event_impl'. setup.py should reflect that.
